### PR TITLE
ADR for Securing JSON Output

### DIFF
--- a/decisions/0002-secure-JSON-output.md
+++ b/decisions/0002-secure-JSON-output.md
@@ -38,23 +38,26 @@ to receive payloads.
 
 ## Proposed Decision
 
-### Mutual TLS over HTTP
-Use mutual TLS over HTTP (HTTPS). This would ensure
+### TLS over HTTP
+Use TLS over HTTP (HTTPS). This would ensure
 encrypted data in transit, which [satisfies MOJ standards](https://ministryofjustice.github.io/security-guidance/standards/cryptography/#cryptography).
+We came to the conclusion that mutual TLS doesn’t really bring any benefits and
+involves way too much management overhead in this context, so agreed on normal
+TLS + payload encryption with a pre-shared secret.
 
-### Signed JSON Payload
-Signing the payload with a pre-shared secret would ensure that payloads are not
-tampered in transit as well as identifying sender.
+### Encrypted JSON Payload
+Encryption of the payload is possible with JWE (JOSE toolkit). This would require
+decryption at the other end. Payload encryption is preferred over TLS alone as TLS
+is often terminated at the edge of a large network with ommunications travelling in the clear
+inside that network. Given the sensitivity of the submitted data for some forms
+and that it may need to be relied on in court, we need more confidence that only
+the intended recipient can read the data and that other actors on that network
+can’t impersonate FB by sending other requests to the endpoint.
 
 ### Shared Secret
 The shared secret will be set as an ENV var in the publisher to be consumed by
-the form's runner instance. The shared secret will be used to sign / confirm
+the form's runner instance. The shared secret will be used to encrypt / decrypt
 the payload.
-
-### Encryption
-Encryption of the payload is possible with JWE (JOSE toolkit). This would require
-decryption at the other end. As TLS is used, it is hoped we can rely solely on TLS
-encryption in transit.
 
 ### Certificates vs Shared Secret
 Both certificates and shared secrets can be used for signing and de-serialising the payload.
@@ -66,18 +69,16 @@ to generate and upload certificates may be too much to ask.
 
 Form Builder:
 - Connects with adapter via HTTPS using a ruby library such as [Net:HTTP](https://ruby-doc.org/stdlib-2.6.3/libdoc/net/http/rdoc/Net/HTTP.html).
-- Connection utlisises mutual TLS using `Net::HTTP verify_mode: OpenSSL::SSL::VERIFY_PEER`.
-- Signs JSON payload using a shared secret and JWS protocol.
+- Connection with TLS using `Net::HTTP` gem or similar.
+- Encrypts JSON payload using a shared secret and JWE protocol.
 - Sends as POST request.
 
 Adapter:
 - Receives HTTPS POST request from Form Builder.
-- Validates JWS signature using shared secret.
+- Decrypts JSON payload using shared secret.
 - Also verifies request header / origin to ensure it was sent from Form Builder.
 
 ## Consequences
 
 Desired level of security is achieved with an easy implementation for users building
 future adapters.
-
-There is no additional application level encryption. TLS over HTTP is relied on for this.

--- a/decisions/0002-secure-JSON-output.md
+++ b/decisions/0002-secure-JSON-output.md
@@ -43,10 +43,14 @@ Signing the payload with a pre-shared secret would ensure that payloads are not
 tampered in transit as well as identifying sender. The adapter could further ensure
 that payloads are only received from Form Builder using HTTP request info.
 
+The shared secret will be set as an ENV var in the publisher to be consumed by
+the form's runner instance.
+
 Overview:
 
 Form Builder:
 - Connects with adapter via HTTPS using a ruby library such as [Net:HTTP](https://ruby-doc.org/stdlib-2.6.3/libdoc/net/http/rdoc/Net/HTTP.html)
+- Connection utlisises mutual TLS using `Net::HTTP verify_mode: OpenSSL::SSL::VERIFY_PEER`
 - Signs JSON payload using a shared secret and JWS protocol
 - Sends as POST request
 

--- a/decisions/0002-secure-JSON-output.md
+++ b/decisions/0002-secure-JSON-output.md
@@ -1,0 +1,66 @@
+# 2. Secure JSON Output
+
+Date: 2019-08-22
+
+## Status
+
+🤔 Proposed
+
+## Context
+
+We are working on a new feature of Form Builder where a form creator (user) can
+opt to have submissions (citizen answers) sent as JSON to an endpoint of their choosing.
+These endpoints can be any url, but will likely be CMS or case management systems.
+
+The first use case of this is the HMCTS complaints form. This form requires an
+integration to HMCTS' Optics system. We will be creating a custom adapter that receives
+the JSON output from Form Builder, and then generates the complaint in Optics. This
+adapter will live outside the Form Builder infrastructure. In the future, the hope
+is that teams will create their own adapters in order to integrate Form Builder
+with various external systems.
+
+This ADR is regarding how to secure this JSON output from Form Builder to the
+endpoint set by the user.
+
+Threats
+- Payload may be intercepted, exposing sensitive user answers.
+- Payload may be modified in transit, with potentially damaging consequences.
+
+Risks
+- Reputational damage due to data breaches
+- Security threats from modified payloads
+
+Mistakes from the User
+- Users could potentially enter an incorrect endpoint, which would deliver sensitive
+data to an incorrect endpoint.
+- Users could share security information accidentally, allowing malicious actors
+to receive payloads.
+
+## Proposed Decision
+Use mutual TLS over HTTP (HTTPS) with serialised/signed JSON payloads. This would ensure
+encrypted data in transit, which [satisfies MOJ standards](https://ministryofjustice.github.io/security-guidance/standards/cryptography/#cryptography).
+Signing the payload with a pre-shared secret would ensure that payloads are not
+tampered in transit as well as identifying sender. The adapter could further ensure
+that payloads are only received from Form Builder using HTTP request info.
+
+Overview:
+
+Form Builder:
+- Connects with adapter via HTTPS using a ruby library such as [Net:HTTP](https://ruby-doc.org/stdlib-2.6.3/libdoc/net/http/rdoc/Net/HTTP.html)
+- Signs JSON payload using a shared secret and JWS protocol
+- Sends as POST request
+
+|
+V
+
+Adapter:
+- Receives HTTPS POST request from Form Builder
+- Validates JWS signature using shared secret
+- Also verifies request header / origin to ensure it was sent from Form Builder (edited
+
+## Consequences
+
+Desired level of security is achieved with an easy implementation for users building
+future adapters.
+
+There is no additional application level encryption. TLS over HTTP is relied on for this.

--- a/decisions/0002-secure-JSON-output.md
+++ b/decisions/0002-secure-JSON-output.md
@@ -25,6 +25,8 @@ endpoint set by the user.
 Threats
 - Payload may be intercepted, exposing sensitive user answers.
 - Payload may be modified in transit, with potentially damaging consequences.
+- POST requests could be made to the receiver (adapter) from sources other than Form Builder,
+  creating records in their systems that don't reflect user submissions.
 
 Risks
 - Reputational damage due to data breaches
@@ -48,7 +50,7 @@ TLS + payload encryption with a pre-shared secret.
 ### Encrypted JSON Payload
 Encryption of the payload is possible with JWE (JOSE toolkit). This would require
 decryption at the other end. Payload encryption is preferred over TLS alone as TLS
-is often terminated at the edge of a large network with ommunications travelling in the clear
+is often terminated at the edge of a large network with communications travelling in the clear
 inside that network. Given the sensitivity of the submitted data for some forms
 and that it may need to be relied on in court, we need more confidence that only
 the intended recipient can read the data and that other actors on that network
@@ -57,12 +59,17 @@ can’t impersonate FB by sending other requests to the endpoint.
 ### Shared Secret
 The shared secret will be set as an ENV var in the publisher to be consumed by
 the form's runner instance. The shared secret will be used to encrypt / decrypt
-the payload.
+the payload. This shared secret would ideally be system generated rather than user
+generated to ensure that it is appropriate for the encryption method we choose.
 
 ### Certificates vs Shared Secret
 Both certificates and shared secrets can be used for signing and de-serialising the payload.
 Given users may not be technical, a shared secret would be preferred as requiring users
 to generate and upload certificates may be too much to ask.
+
+### Validation of remote endpoint
+The Form Builder system should validate the endpoint that is entered by the user.
+At minimum this should an an HTTPS endpoint and `*.gov.uk`.
 
 
 ### Overview of Solution
@@ -76,7 +83,6 @@ Form Builder:
 Adapter:
 - Receives HTTPS POST request from Form Builder.
 - Decrypts JSON payload using shared secret.
-- Also verifies request header / origin to ensure it was sent from Form Builder.
 
 ## Consequences
 

--- a/decisions/0002-secure-JSON-output.md
+++ b/decisions/0002-secure-JSON-output.md
@@ -38,41 +38,37 @@ to receive payloads.
 
 ## Proposed Decision
 
-Mutual TLS over HTTP
+### Mutual TLS over HTTP
 Use mutual TLS over HTTP (HTTPS). This would ensure
 encrypted data in transit, which [satisfies MOJ standards](https://ministryofjustice.github.io/security-guidance/standards/cryptography/#cryptography).
 
-Signed JSON Payload
+### Signed JSON Payload
 Signing the payload with a pre-shared secret would ensure that payloads are not
 tampered in transit as well as identifying sender.
 
-Shared Secret
+### Shared Secret
 The shared secret will be set as an ENV var in the publisher to be consumed by
 the form's runner instance. The shared secret will be used to sign / confirm
 the payload.
 
-Encryption
+### Encryption
 Encryption of the payload is possible with JWE (JOSE toolkit). This would require
 decryption at the other end. As TLS is used, it is hoped we can rely solely on TLS
 encryption in transit.
 
-Certificates vs Shared Secret
+### Certificates vs Shared Secret
 Both certificates and shared secrets can be used for signing and de-serialising the payload.
 Given users may not be technical, a shared secret would be preferred as requiring users
 to generate and upload certificates may be too much to ask.
 
 
-Overview:
+### Overview of Solution
 
 Form Builder:
 - Connects with adapter via HTTPS using a ruby library such as [Net:HTTP](https://ruby-doc.org/stdlib-2.6.3/libdoc/net/http/rdoc/Net/HTTP.html).
 - Connection utlisises mutual TLS using `Net::HTTP verify_mode: OpenSSL::SSL::VERIFY_PEER`.
 - Signs JSON payload using a shared secret and JWS protocol.
 - Sends as POST request.
-
-|
-
-V
 
 Adapter:
 - Receives HTTPS POST request from Form Builder.

--- a/decisions/0002-secure-JSON-output.md
+++ b/decisions/0002-secure-JSON-output.md
@@ -69,7 +69,7 @@ to generate and upload certificates may be too much to ask.
 
 ### Validation of remote endpoint
 The Form Builder system should validate the endpoint that is entered by the user.
-At minimum this should an an HTTPS endpoint and `*.gov.uk`.
+At minimum this should be an HTTPS endpoint and `*.gov.uk`.
 
 
 ### Overview of Solution

--- a/decisions/0002-secure-JSON-output.md
+++ b/decisions/0002-secure-JSON-output.md
@@ -37,30 +37,47 @@ data to an incorrect endpoint.
 to receive payloads.
 
 ## Proposed Decision
-Use mutual TLS over HTTP (HTTPS) with serialised/signed JSON payloads. This would ensure
-encrypted data in transit, which [satisfies MOJ standards](https://ministryofjustice.github.io/security-guidance/standards/cryptography/#cryptography).
-Signing the payload with a pre-shared secret would ensure that payloads are not
-tampered in transit as well as identifying sender. The adapter could further ensure
-that payloads are only received from Form Builder using HTTP request info.
 
+Mutual TLS over HTTP
+Use mutual TLS over HTTP (HTTPS). This would ensure
+encrypted data in transit, which [satisfies MOJ standards](https://ministryofjustice.github.io/security-guidance/standards/cryptography/#cryptography).
+
+Signed JSON Payload
+Signing the payload with a pre-shared secret would ensure that payloads are not
+tampered in transit as well as identifying sender.
+
+Shared Secret
 The shared secret will be set as an ENV var in the publisher to be consumed by
-the form's runner instance.
+the form's runner instance. The shared secret will be used to sign / confirm
+the payload.
+
+Encryption
+Encryption of the payload is possible with JWE (JOSE toolkit). This would require
+decryption at the other end. As TLS is used, it is hoped we can rely solely on TLS
+encryption in transit.
+
+Certificates vs Shared Secret
+Both certificates and shared secrets can be used for signing and de-serialising the payload.
+Given users may not be technical, a shared secret would be preferred as requiring users
+to generate and upload certificates may be too much to ask.
+
 
 Overview:
 
 Form Builder:
-- Connects with adapter via HTTPS using a ruby library such as [Net:HTTP](https://ruby-doc.org/stdlib-2.6.3/libdoc/net/http/rdoc/Net/HTTP.html)
-- Connection utlisises mutual TLS using `Net::HTTP verify_mode: OpenSSL::SSL::VERIFY_PEER`
-- Signs JSON payload using a shared secret and JWS protocol
-- Sends as POST request
+- Connects with adapter via HTTPS using a ruby library such as [Net:HTTP](https://ruby-doc.org/stdlib-2.6.3/libdoc/net/http/rdoc/Net/HTTP.html).
+- Connection utlisises mutual TLS using `Net::HTTP verify_mode: OpenSSL::SSL::VERIFY_PEER`.
+- Signs JSON payload using a shared secret and JWS protocol.
+- Sends as POST request.
 
 |
+
 V
 
 Adapter:
-- Receives HTTPS POST request from Form Builder
-- Validates JWS signature using shared secret
-- Also verifies request header / origin to ensure it was sent from Form Builder (edited
+- Receives HTTPS POST request from Form Builder.
+- Validates JWS signature using shared secret.
+- Also verifies request header / origin to ensure it was sent from Form Builder.
 
 ## Consequences
 

--- a/decisions/decisions.md
+++ b/decisions/decisions.md
@@ -6,6 +6,7 @@ see [ADR-001](0001-record-architecture-decisions.md).
 ## Table of contents
 
 * ✅ [1. Record architecture decisions](0001-record-architecture-decisions.md) (accepted)
+* 🤔 [2. Secure JSON Output](0002-secure-JSON-output.md) (proposed)
 
 ### Statuses:
 


### PR DESCRIPTION
ADR for securing the JSON output payload.

STATUS: Proposed

See formatted markdown here: https://github.com/ministryofjustice/form-builder/blob/json-output-security-adr/decisions/0002-secure-JSON-output.md

Jira card, containing some discussion: https://dsdmoj.atlassian.net/jira/software/projects/FB/boards/323?selectedIssue=FB-525