### PR TITLE
Document Rolling updates

### DIFF
--- a/documentation/documentation.md
+++ b/documentation/documentation.md
@@ -26,4 +26,5 @@
 
 ## Misc
 
+- [Rolling Runner Updates](form_updates.md)
 - [Concepts and glossary](glossary.md)

--- a/documentation/form_updates.md
+++ b/documentation/form_updates.md
@@ -1,0 +1,16 @@
+# Form Updates
+
+Currently forms will not use the latest version of the [Runner](https://github.com/ministryofjustice/fb-runner-node) until they are manually re-deployed by the form owner.
+
+This poses a challenge when rolling out new functionality or applying security patches.
+The long term goal is to have all forms use the latest version of the Runner as soon as we release it.
+
+For the time being, if all forms need to be updated to use the latest Runner code, this command can be run:
+
+```bash
+kubectl rollout restart deployments -n formbuilder-services-[env]
+```
+
+This will not update the actual form JSON (if a new release was pushed to Github), so there is no risk of publishing draft form features.
+
+*env can be any of the 9 environments like test-dev*


### PR DESCRIPTION
Until we can automatically have forms use the latest Runner version, we need a way to do a rolling restart.  Document the kubectl command to do this.