### PR TITLE
Add info about database backups to platform documentation

### DIFF
--- a/documentation/platform/database-backups/database-backups.md
+++ b/documentation/platform/database-backups/database-backups.md
@@ -1,0 +1,16 @@
+# Database Backups
+
+## RDS Snapshots
+All databases are backed up once per day. These are automated RDS instance
+snapshots that AWS provides. A snapshot can also be triggered using the AWS
+CLI via the command line using the IAM user which was created with our RDS.
+
+## Restoring Snapshots
+You can restore an RDS snapshot via the AWS console, or you can do it via the
+command line. Snapshots are held for one week by default. This can be changed.
+
+## Changing Frequency of Snapshots
+Cloud Platform don't think the automated frequency can be increased beyond once
+per day. However several other methods exist to perform automated backups such
+as creating a cron job to trigger a backup via the AWS CLI, using a CircleCI
+pipeline or backing up the data in some other way (e.g. pg_dump).

--- a/documentation/platform/platform.md
+++ b/documentation/platform/platform.md
@@ -26,3 +26,4 @@
 - [Signing requests with JWT](request-signing-with-jwt.md)
 - [Sending error responses](error-responses.md)
 - [Logging](logging.md)
+- [Database Backups](./database-backups/database-backups.md)


### PR DESCRIPTION
Documentation on our database backups. This information was direct from Cloud Platform.